### PR TITLE
Simple method for providing more params to blastn

### DIFF
--- a/diagnostic_primers/blast.py
+++ b/diagnostic_primers/blast.py
@@ -60,7 +60,8 @@ from Bio.Blast.Applications import NcbiblastnCommandline
 from diagnostic_primers import load_primers, write_primers
 
 
-def build_commands(collection, blastexe, blastdb, outdir=None, existingfiles=[]):
+def build_commands(collection, blastexe, blastdb, outdir=None,
+                   existingfiles=[], extra_blast_params=''):
     """Builds and returns a list of BLASTN command lines for screening
 
     The returned commands run BLASTN using primer sequences for each
@@ -73,7 +74,7 @@ def build_commands(collection, blastexe, blastdb, outdir=None, existingfiles=[])
     sequences are placed in the specified output directory.
     """
     clines = []
-
+    
     # Create output directory if required
     if outdir:
         os.makedirs(outdir, exist_ok=True)
@@ -92,6 +93,7 @@ def build_commands(collection, blastexe, blastdb, outdir=None, existingfiles=[])
         cline = build_blastscreen_cmd(fastafname, blastexe, blastdb, outdir)
         if os.path.split(cline.out)[-1] not in existingfiles:
             clines.append(cline)
+        cline = ' '.join([str(cline), extra_blast_params])
     return clines
 
 

--- a/diagnostic_primers/scripts/parsers/blastscreen_parser.py
+++ b/diagnostic_primers/scripts/parsers/blastscreen_parser.py
@@ -61,6 +61,7 @@ def build(subparsers, parents=None):
         dest="bs_exe",
         action="store",
         default="blastn",
+        type=str,
         help="path to BLASTN+ executable",
     )
     parser.add_argument(
@@ -68,21 +69,23 @@ def build(subparsers, parents=None):
         dest="bs_db",
         action="store",
         default="nr",
+        type=str,
         help="path to BLASTN+ database",
     )
     parser.add_argument(
         "--maxaln",
         dest="maxaln",
         action="store",
-        default=15,
-        type=int,
-        help="exclude primers with longer alignment",
+        default=0.75,
+        type=float,
+        help="BLASTn hits with aln length >X (frac.) of primer length are considered valid"
     )
     parser.add_argument(
         "--outdir",
         dest="bs_dir",
         action="store",
         default="blastn",
+        type=str,
         help="path to directory for BLASTN+ output",
     )
     parser.add_argument(
@@ -105,6 +108,28 @@ def build(subparsers, parents=None):
         "--extra-blast-params",
         dest="extra_blast_params",
         default='',
+        type=str,
         help="Extra parameters to pass to blastn",
+    )
+    parser.add_argument(
+        "--max-target-seqs",
+        dest="max_target_seqs",
+        default=1,
+        type=int,
+        help="BLASTn -max_target_seqs param"
+    )
+    parser.add_argument(
+        "--perc-identity",
+        dest="perc_identity",
+        default=90,
+        type=float,
+        help="BLASTn -perc_identity param",
+    )
+    parser.add_argument(
+        "--filter-list",
+        dest="filter_list",
+        default=None,
+        type=str,
+        help="comma-sep list of regex to filter hits by scientific name",
     )
     parser.set_defaults(func=subcommands.subcmd_blastscreen)

--- a/diagnostic_primers/scripts/parsers/blastscreen_parser.py
+++ b/diagnostic_primers/scripts/parsers/blastscreen_parser.py
@@ -99,4 +99,11 @@ def build(subparsers, parents=None):
         default=False,
         help="Overwrite old BLASTN+ output",
     )
+    parser.add_argument(
+        "-x",
+        "--extra-blast-params",
+        dest="extra_blast_params",
+        default='',
+        help="Extra parameters to pass to blastn",
+    )
     parser.set_defaults(func=subcommands.subcmd_blastscreen)

--- a/diagnostic_primers/scripts/subcommands/subcmd_blastscreen.py
+++ b/diagnostic_primers/scripts/subcommands/subcmd_blastscreen.py
@@ -87,7 +87,8 @@ def subcmd_blastscreen(args, logger):
     # Run BLASTN search with primer sequences
     logger.info("Building BLASTN screen command-lines...")
     clines = blast.build_commands(
-        coll, args.bs_exe, args.bs_db, args.bs_dir, existingfiles, args.extra_blast_params
+        coll, args.bs_exe, args.bs_db, args.bs_dir, existingfiles, args.extra_blast_params,
+        args.max_target_seqs, args.perc_identity
     )
     if clines:
         pretty_clines = [str(c).replace(" -", " \\\n          -") for c in clines]
@@ -109,7 +110,8 @@ def subcmd_blastscreen(args, logger):
             "Amending primer file %s with results from %s", indata.primers, blastout
         )
         newprimers = blast.apply_screen(
-            blastout, indata.primers, jsondir=args.bs_jsondir, maxaln=args.maxaln
+            blastout, indata.primers, jsondir=args.bs_jsondir, maxaln=args.maxaln,
+            filter_list=args.filter_list
         )
         logger.info("Screened primers placed in %s", newprimers)
         indata.primers = newprimers

--- a/diagnostic_primers/scripts/subcommands/subcmd_blastscreen.py
+++ b/diagnostic_primers/scripts/subcommands/subcmd_blastscreen.py
@@ -87,7 +87,7 @@ def subcmd_blastscreen(args, logger):
     # Run BLASTN search with primer sequences
     logger.info("Building BLASTN screen command-lines...")
     clines = blast.build_commands(
-        coll, args.bs_exe, args.bs_db, args.bs_dir, existingfiles
+        coll, args.bs_exe, args.bs_db, args.bs_dir, existingfiles, args.extra_blast_params
     )
     if clines:
         pretty_clines = [str(c).replace(" -", " \\\n          -") for c in clines]

--- a/tests/walkthrough/pectoconf.tab
+++ b/tests/walkthrough/pectoconf.tab
@@ -1,7 +1,7 @@
 # Pectobacterium genomes downloaded from GenBank/NCBI; genomovars inferred from ANIm
 # Annotated Pba: genomovar 1
-Pba_SCRI1043	Pectobacterium,atrosepticum_NCBI,gv1	tests/walkthrough/sequences/GCF_000011605.1.fasta	-
+Pba_SCRI1043	Pectobacterium,atrosepticum_NCBI,gv1,all	tests/walkthrough/sequences/GCF_000011605.1.fasta	-
 # Annotated Pwa: genomovars 2, 3
-Pwa_CFBP_3304	Pectobacterium,wasabiae_NCBI,gv2	tests/walkthrough/sequences/GCF_000291725.1.fasta	-
+Pwa_CFBP_3304	Pectobacterium,wasabiae_NCBI,gv2,all	tests/walkthrough/sequences/GCF_000291725.1.fasta	-
 # Annotated Pb	: genomovar 7
-Pbe_NCPPB_2795	Pectobacterium,betavasculorum_NCBI,gv7	tests/walkthrough/sequences/GCF_000749845.1.fasta	-
+Pbe_NCPPB_2795	Pectobacterium,betavasculorum_NCBI,gv7,all	tests/walkthrough/sequences/GCF_000749845.1.fasta	-

--- a/tests/walkthrough/pectoconf.tab
+++ b/tests/walkthrough/pectoconf.tab
@@ -1,7 +1,7 @@
 # Pectobacterium genomes downloaded from GenBank/NCBI; genomovars inferred from ANIm
 # Annotated Pba: genomovar 1
-Pba_SCRI1043	Pectobacterium,atrosepticum_NCBI,gv1,all	tests/walkthrough/sequences/GCF_000011605.1.fasta	-
+Pba_SCRI1043	Pectobacterium,atrosepticum_NCBI,gv1	tests/walkthrough/sequences/GCF_000011605.1.fasta	-
 # Annotated Pwa: genomovars 2, 3
-Pwa_CFBP_3304	Pectobacterium,wasabiae_NCBI,gv2,all	tests/walkthrough/sequences/GCF_000291725.1.fasta	-
+Pwa_CFBP_3304	Pectobacterium,wasabiae_NCBI,gv2	tests/walkthrough/sequences/GCF_000291725.1.fasta	-
 # Annotated Pb	: genomovar 7
-Pbe_NCPPB_2795	Pectobacterium,betavasculorum_NCBI,gv7,all	tests/walkthrough/sequences/GCF_000749845.1.fasta	-
+Pbe_NCPPB_2795	Pectobacterium,betavasculorum_NCBI,gv7	tests/walkthrough/sequences/GCF_000749845.1.fasta	-


### PR DESCRIPTION
For `pdp blastscreen`, it appears that if the users blasts their primers against NCBI nt, then they will filter out the primers that hit their target taxa (assuming those taxa are in nt). I therefore made a simple addition to `pdp blastscreen` that allows the user to provide extra arguments to blastn such as `-negative_taxids 561` in order to exclude the user's targets from the blast search. An example command would be:

```
pdp blastscreen -x "-negative_taxids 561" --force --db /path/to/NCBI_blastdb/nt --outdir blastn deduped_primers.json screened.json
```